### PR TITLE
Make getUri more readable

### DIFF
--- a/src/Controller/UriController.php
+++ b/src/Controller/UriController.php
@@ -31,13 +31,9 @@ class UriController extends AbstractController
         }
 
         try {
-            $uri = $manager->getUri(
-                new GetUriRequest($shortCode)
-            );
+            $uri = $manager->getGuaranteedUri(new GetUriRequest($shortCode));
+            return $this->createRedirectResponseTo($uri->getOriginalUrl());
 
-            if (null !== $uri) {
-                return $this->createRedirectResponseTo($uri->getOriginalUrl());
-            }
         } catch (NonUniqueResultException $exception) {
         }
 

--- a/src/Controller/UriController.php
+++ b/src/Controller/UriController.php
@@ -25,22 +25,23 @@ class UriController extends AbstractController
      */
     public function getUri(Request $request, UriManager $manager): RedirectResponse
     {
-        $response = new RedirectResponse('/', Response::HTTP_MOVED_PERMANENTLY);
-
-        if ($shortCode = $request->attributes->get('short_code')) {
-            try {
-                $uri = $manager->getUri(
-                    new GetUriRequest($shortCode)
-                );
-
-                if (null !== $uri) {
-                    $response->setTargetUrl($uri->getOriginalUrl());
-                }
-            } catch (NonUniqueResultException $exception) {
-            }
+        $shortCode = $request->attributes->get('short_code');
+        if ($shortCode === null) {
+            return $this->createRedirectResponseTo('/');
         }
 
-        return $response;
+        try {
+            $uri = $manager->getUri(
+                new GetUriRequest($shortCode)
+            );
+
+            if (null !== $uri) {
+                return $this->createRedirectResponseTo($uri->getOriginalUrl());
+            }
+        } catch (NonUniqueResultException $exception) {
+        }
+
+        return $this->createRedirectResponseTo('/');
     }
 
     /**
@@ -75,6 +76,17 @@ class UriController extends AbstractController
             $statusText,
             Response::HTTP_CREATED
         );
+    }
+
+    /**
+     * Create redirect response to given uri
+     *
+     * @param string $uri
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    private function createRedirectResponseTo(string $uri): RedirectResponse
+    {
+        return new RedirectResponse($uri, Response::HTTP_MOVED_PERMANENTLY);
     }
 
     /**

--- a/src/Service/UriManager.php
+++ b/src/Service/UriManager.php
@@ -26,6 +26,27 @@ final class UriManager
     }
 
     /**
+     * Returns an Uri by looking for a hash if nothing is found a default Uri is returned
+     *
+     * @param \App\Struct\GetUriRequest $request
+     * @param string                    $defaultUrl
+     *
+     * @return \App\Entity\Uri
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    public function getGuaranteedUri(GetUriRequest $request, string $defaultUrl = '/'): Uri
+    {
+        $uri = $this->getUri($request);
+
+        if ($uri === null) {
+            $uri = new Uri();
+            $uri->setOriginalUrl($defaultUrl);
+        }
+
+        return $uri;
+    }
+
+    /**
      * @param GetUriRequest $request
      *
      * @return Uri|null


### PR DESCRIPTION
Moved a bit of code around to prevent too many layers of indentation.

This one I'm not so sure about because of the shattered returns all over the place, but I think I still prefer this because of readability.